### PR TITLE
optional bearer token prefix

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -2,10 +2,12 @@ package oidc
 
 import (
 	"fmt"
-	"github.com/go-http-utils/headers"
 	"net/http"
 	"otc-auth/common"
 	"otc-auth/common/endpoints"
+	"strings"
+
+	"github.com/go-http-utils/headers"
 )
 
 func AuthenticateAndGetUnscopedToken(authInfo common.AuthInfo) common.TokenResponse {
@@ -23,8 +25,12 @@ func authenticateWithServiceProvider(oidcCredentials common.OidcCredentialsRespo
 	url := endpoints.IdentityProviders(authInfo.IdpName, authInfo.AuthProtocol)
 
 	request := common.GetRequest(http.MethodPost, url, nil)
+
+	if !strings.HasPrefix(oidcCredentials.BearerToken, "Bearer ") {
+		oidcCredentials.BearerToken = fmt.Sprintf("Bearer %s", oidcCredentials.BearerToken)
+	}
 	request.Header.Add(
-		headers.Authorization, fmt.Sprintf("Bearer %s", oidcCredentials.BearerToken),
+		headers.Authorization, oidcCredentials.BearerToken,
 	)
 
 	response := common.HttpClientMakeRequest(request)


### PR DESCRIPTION
The changes regarding the bearer token break the login with AzureAd as the token already is prefixed with "Bearer ". I added a check to just optionally prefix the Token with "Bearer". If tested this with AzureAD but am not able to test with Keycloak etc.