### PR TITLE
Pass region argument to the rest of the app

### DIFF
--- a/common/http_client.go
+++ b/common/http_client.go
@@ -45,7 +45,7 @@ func GetBodyBytesFromResponse(response *http.Response) []byte {
 
 	statusCodeStartsWith2 := regexp.MustCompile(`2\d{2}`)
 	if !statusCodeStartsWith2.MatchString(strconv.Itoa(response.StatusCode)) {
-		errorMessage := fmt.Sprintf("error: status %s, body:\n%s", response.Status, ByteSliceToIndentedJSONFormat(bodyBytes))
+		errorMessage := fmt.Sprintf("error: status %s, body:\n%s", response.Status, bodyBytes)
 		OutputErrorMessageToConsoleAndExit(errorMessage)
 	}
 

--- a/main.go
+++ b/main.go
@@ -207,10 +207,10 @@ func main() {
 			Username:      getUsernameOrThrow(*username),
 			Password:      getPasswordOrThrow(*password),
 			DomainName:    getDomainNameOrThrow(*domainName),
-			Region:        getRegionCodeOrThrow(*regionCode),
 			Otp:           totpToken,
 			UserDomainID:  userID,
 			OverwriteFile: *overwriteToken,
+			Region:        getRegionCodeOrThrow(*regionCode),
 		}
 
 		AuthenticateAndGetUnscopedToken(authInfo)
@@ -227,6 +227,7 @@ func main() {
 			IdpURL:        identityProviderURL,
 			AuthProtocol:  protocolSAML,
 			OverwriteFile: *overwriteToken,
+			Region:        getRegionCodeOrThrow(*regionCode),
 		}
 
 		AuthenticateAndGetUnscopedToken(authInfo)


### PR DESCRIPTION
When logging in with saml-idp, the region argument wasn't passed to the rest of the app, raising an error.