### PR TITLE
Add flag to output kubeconfig

### DIFF
--- a/cce/cce.go
+++ b/cce/cce.go
@@ -15,6 +15,7 @@ import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func GetClusterNames(projectName string) config.Clusters {
@@ -38,12 +39,44 @@ func GetClusterNames(projectName string) config.Clusters {
 	return clustersArr
 }
 
-func GetKubeConfig(configParams KubeConfigParams) {
-	kubeConfig := getKubeConfig(configParams)
+func GetKubeConfig(configParams KubeConfigParams, printKubeConfig bool) {
+	kubeConfigData := getKubeConfig(configParams)
 
-	mergeKubeConfig(configParams, kubeConfig)
+	kubeConfigContextData := addContextInformationToKubeConfig(configParams.ProjectName,
+		configParams.ClusterName, kubeConfigData)
 
-	log.Printf("Successfully fetched and merge kube config for cce cluster %s. \n", configParams.ClusterName)
+	clientConfig, err := clientcmd.NewClientConfigFromBytes([]byte(kubeConfigContextData))
+	if err != nil {
+		common.OutputErrorToConsoleAndExit(err)
+	}
+	kubeConfig, err := clientConfig.RawConfig()
+	if err != nil {
+		common.OutputErrorToConsoleAndExit(err)
+	}
+
+	if configParams.Server != "" {
+		kubeConfigBkp := kubeConfig
+		for idx := range kubeConfigBkp.Clusters {
+			kubeConfig.Clusters[idx].Server = configParams.Server
+		}
+	}
+
+	if printKubeConfig {
+		configBytes, errMarshal := json.Marshal(kubeConfig)
+		if errMarshal != nil {
+			common.OutputErrorToConsoleAndExit(errMarshal)
+		}
+		configBytes = append([]byte{'\n'}, configBytes...)
+		configBytes = append(configBytes, '\n', '\n')
+		_, errWriter := log.Writer().Write(configBytes)
+		if err != nil {
+			common.OutputErrorToConsoleAndExit(errWriter)
+		}
+		log.Printf("Successfully fetched kube config for cce cluster %s. \n", configParams.ClusterName)
+	} else {
+		mergeKubeConfig(configParams, kubeConfig)
+		log.Printf("Successfully fetched and merge kube config for cce cluster %s. \n", configParams.ClusterName)
+	}
 }
 
 func getClustersForProjectFromServiceProvider(projectName string) ([]clusters.Clusters, error) {

--- a/cce/kube_config.go
+++ b/cce/kube_config.go
@@ -13,6 +13,7 @@ import (
 	"otc-auth/config"
 
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 )
 
@@ -35,19 +36,8 @@ func getKubeConfig(kubeConfigParams KubeConfigParams) string {
 	return string(responseMarshalled)
 }
 
-func mergeKubeConfig(configParams KubeConfigParams, kubeConfigData string) {
-	kubeConfigContextData := addContextInformationToKubeConfig(configParams.ProjectName,
-		configParams.ClusterName, kubeConfigData)
+func mergeKubeConfig(configParams KubeConfigParams, kubeConfig api.Config) {
 	currentConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().GetStartingConfig()
-	if err != nil {
-		common.OutputErrorToConsoleAndExit(err)
-	}
-
-	clientConfig, err := clientcmd.NewClientConfigFromBytes([]byte(kubeConfigContextData))
-	if err != nil {
-		common.OutputErrorToConsoleAndExit(err)
-	}
-	kubeConfig, err := clientConfig.RawConfig()
 	if err != nil {
 		common.OutputErrorToConsoleAndExit(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -183,7 +183,7 @@ var cceGetKubeConfigCmd = &cobra.Command{
 			Server:         server,
 		}
 
-		cce.GetKubeConfig(kubeConfigParams)
+		cce.GetKubeConfig(kubeConfigParams, printKubeConfig)
 	},
 }
 
@@ -374,6 +374,8 @@ func setupRootCmd() {
 
 	cceCmd.AddCommand(cceGetKubeConfigCmd)
 	cceListCmd.Flags().StringVarP(&region, regionFlag, regionShortFlag, "", regionUsage)
+	cceGetKubeConfigCmd.Flags().BoolVarP(&printKubeConfig, printKubeConfigFlag, printKubeConfigShortFlag,
+		false, printKubeConfigUsage)
 	cceGetKubeConfigCmd.Flags().StringVarP(&clusterName, clusterNameFlag, clusterNameShortFlag, "", clusterNameUsage)
 	cceGetKubeConfigCmd.Flags().IntVarP(
 		&daysValid,
@@ -486,6 +488,7 @@ var (
 	token                               string
 	openStackConfigLocation             string
 	skipTLS                             bool
+	printKubeConfig                     bool
 	clientSecret                        string
 	clientID                            string
 	oidcScopes                          []string
@@ -703,6 +706,9 @@ $ otc-auth access-token delete --token YourToken --os-domain-name YourDomain`
 	projectNameShortFlag                         = "p"
 	projectNameEnv                               = "OS_PROJECT_NAME"
 	projectNameUsage                             = "Name of the project you want to access. Either provide this argument or set the environment variable " + projectNameEnv
+	printKubeConfigFlag                          = "output"
+	printKubeConfigShortFlag                     = "o"
+	printKubeConfigUsage                         = "Output fetched kube config to stdout instead of merging it with your existing kube config"
 	clusterNameFlag                              = "cluster"
 	clusterNameShortFlag                         = "c"
 	clusterNameEnv                               = "CLUSTER_NAME"


### PR DESCRIPTION
`-o` or `--output` will print the fetched kubeconfig out to the terminal instead of merging it with the local config 