### PR TITLE
Remove unneeded region flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -373,7 +373,6 @@ func setupRootCmd() {
 	cceCmd.AddCommand(cceListCmd)
 
 	cceCmd.AddCommand(cceGetKubeConfigCmd)
-	cceListCmd.Flags().StringVarP(&region, regionFlag, regionShortFlag, "", regionUsage)
 	cceGetKubeConfigCmd.Flags().StringVarP(&clusterName, clusterNameFlag, clusterNameShortFlag, "", clusterNameUsage)
 	cceGetKubeConfigCmd.Flags().IntVarP(
 		&daysValid,
@@ -395,7 +394,6 @@ func setupRootCmd() {
 		"~/.kube/config",
 		targetLocationUsage,
 	)
-	cceGetKubeConfigCmd.Flags().StringVarP(&region, regionFlag, regionShortFlag, "", regionUsage)
 
 	RootCmd.AddCommand(tempAccessTokenCmd)
 	tempAccessTokenCmd.PersistentFlags().StringVarP(&domainName, domainNameFlag, domainNameShortFlag, "", domainNameUsage)


### PR DESCRIPTION
The region is read from the otc config file after login, so `-r` shouldn't exist on the cce level.