### PR TITLE
Fix oidc error exit number

### DIFF
--- a/accesstoken/accesstoken.go
+++ b/accesstoken/accesstoken.go
@@ -17,7 +17,7 @@ import (
 )
 
 func CreateAccessToken(tokenDescription string) {
-	log.Println("Creating access token file with GTC...")
+	log.Println("info: creating access token file with GTC...")
 	resp, err := getAccessTokenFromServiceProvider(tokenDescription)
 	if err != nil {
 		// A 404 error is thrown when trying to create a permanent AK/SK when logged in with OIDC or SAML
@@ -63,12 +63,12 @@ func makeAccessFile(resp *credentials.Credential, tempResp *credentials.Temporar
 	}
 
 	common.WriteStringToFile("./ak-sk-env.sh", accessKeyFileContent)
-	log.Println("Access token file created successfully")
-	log.Println("Please source the ak-sk-env.sh file in the current directory manually")
+	log.Println("info: access token file created successfully")
+	log.Println("info: please source the ak-sk-env.sh file in the current directory manually")
 }
 
 func CreateTemporaryAccessToken(durationSeconds int) error {
-	log.Println("Creating temporary access token file with GTC...")
+	log.Println("info: creating temporary access token file with GTC...")
 	resp, err := getTempAccessTokenFromServiceProvider(durationSeconds)
 	if err != nil {
 		return err
@@ -140,7 +140,7 @@ func handlePotentialLimitError(err error,
 
 		//nolint:gomnd // The OpenTelekomCloud only lets users have up to two keys
 		if len(accessTokens) == 2 {
-			log.Printf("Hit the limit for access keys on OTC. You can only have 2. Removing keys made by otc-auth...")
+			log.Printf("warning: hit the limit for access keys on OTC. You can only have 2. Removing keys made by otc-auth...")
 			return conditionallyReplaceAccessTokens(user, client, tokenDescription, accessTokens)
 		}
 		return nil, err

--- a/cce/cce.go
+++ b/cce/cce.go
@@ -34,7 +34,7 @@ func GetClusterNames(projectName string) config.Clusters {
 	}
 
 	config.UpdateClusters(clustersArr)
-	log.Printf("CCE Clusters for project %s:\n%s", projectName, strings.Join(clustersArr.GetClusterNames(), ",\n"))
+	log.Printf("info: CCE clusters for project %s:\n%s", projectName, strings.Join(clustersArr.GetClusterNames(), ",\n"))
 
 	return clustersArr
 }
@@ -68,10 +68,10 @@ func GetKubeConfig(configParams KubeConfigParams, skipKubeTLS bool, printKubeCon
 		if err != nil {
 			log.Fatal(errWriter)
 		}
-		log.Printf("Successfully fetched kube config for cce cluster %s. \n", configParams.ClusterName)
+		log.Printf("info: successfully fetched kube config for cce cluster %s. \n", configParams.ClusterName)
 	} else {
 		mergeKubeConfig(configParams, kubeConfig)
-		log.Printf("Successfully fetched and merge kube config for cce cluster %s. \n", configParams.ClusterName)
+		log.Printf("info: successfully fetched and merge kube config for cce cluster %s. \n", configParams.ClusterName)
 	}
 }
 
@@ -145,7 +145,7 @@ func getClusterID(clusterName string, projectName string) (clusterID string, err
 			ID:   cluster.Metadata.Id,
 		})
 	}
-	log.Printf("Clusters for project %s:\n%s", projectName, strings.Join(clusterArr.GetClusterNames(), ",\n"))
+	log.Printf("info: clusters for project %s:\n%s", projectName, strings.Join(clusterArr.GetClusterNames(), ",\n"))
 
 	config.UpdateClusters(clusterArr)
 	cloud = config.GetActiveCloudConfig()

--- a/cce/kube_config.go
+++ b/cce/kube_config.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getKubeConfig(kubeConfigParams KubeConfigParams) (api.Config, error) {
-	log.Println("Getting kube config...")
+	log.Println("info: getting kube config...")
 
 	clusterID, err := getClusterID(kubeConfigParams.ClusterName, kubeConfigParams.ProjectName)
 	if err != nil {

--- a/common/http_client.go
+++ b/common/http_client.go
@@ -36,24 +36,31 @@ func GetRequest(method string, url string, body io.Reader) *http.Request {
 	return request
 }
 
+func closeStreamCheckErr(body io.ReadCloser, err error) {
+	errBodyClose := body.Close()
+	if errBodyClose != nil {
+		err = fmt.Errorf("fatal: %w\nfatal: error closing response body\n%w", err, errBodyClose)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func GetBodyBytesFromResponse(response *http.Response) []byte {
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			log.Fatalf("fatal: error closing response body.\ntrace: %s", err)
-		}
-	}(response.Body)
+	var err error
 
 	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
-		log.Printf("fatal: error reading response body.\ntrace: %s", err)
+		err = fmt.Errorf("fatal: error reading response body\n%w", err)
+		closeStreamCheckErr(response.Body, err)
 	}
 
 	statusCodeStartsWith2 := regexp.MustCompile(`2\d{2}`)
 	if !statusCodeStartsWith2.MatchString(strconv.Itoa(response.StatusCode)) {
-		errorMessage := fmt.Sprintf("error: status %s, body:\n%s", response.Status, bodyBytes)
-		log.Print(errorMessage)
+		err = fmt.Errorf("fatal: status %s, body:\n%s", response.Status, bodyBytes)
+		closeStreamCheckErr(response.Body, err)
 	}
 
+	defer closeStreamCheckErr(response.Body, err)
 	return bodyBytes
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ func LoadCloudConfig(domainName string) {
 	otcConfig.Clouds = clouds
 	writeOtcConfigContentToFile(otcConfig)
 
-	log.Printf("Cloud %s loaded successfully and set to active.\n", domainName)
+	log.Printf("info: cloud %s loaded successfully and set to active.\n", domainName)
 }
 
 func registerNewCloud(domainName string) Clouds {

--- a/config/model.go
+++ b/config/model.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"time"
 
@@ -43,7 +43,7 @@ func (clouds *Clouds) SetActiveByName(name string) {
 
 func (clouds *Clouds) FindActiveCloudConfigOrNil() (cloud *Cloud, index *int, err error) {
 	if clouds.NumberOfActiveCloudConfigs() > 1 {
-		return nil, nil, fmt.Errorf("more than one cloud active")
+		return nil, nil, errors.New("more than one cloud active")
 	}
 
 	for index, cloud := range *clouds {
@@ -52,7 +52,7 @@ func (clouds *Clouds) FindActiveCloudConfigOrNil() (cloud *Cloud, index *int, er
 		}
 	}
 
-	return nil, nil, fmt.Errorf("no active cloud")
+	return nil, nil, errors.New("no active cloud")
 }
 
 func (clouds *Clouds) GetActiveCloudIndex() int {

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -64,10 +64,10 @@ func GetScopedToken(projectName string) config.Token {
 		}
 	}
 
-	log.Println("attempting to request a scoped token")
+	log.Println("info: attempting to request a scoped token")
 	cloud := getCloudWithScopedTokenFromServiceProvider(projectName)
 	config.UpdateCloudConfig(cloud)
-	log.Println("scoped token acquired successfully")
+	log.Println("info: scoped token acquired successfully")
 	project = config.GetActiveCloudConfig().Projects.GetProjectByNameOrThrow(projectName)
 	return project.ScopedToken
 }

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -64,7 +64,7 @@ func GetScopedToken(projectName string) config.Token {
 		}
 	}
 
-	log.Println("info: attempting to request a scoped token")
+	log.Printf("info: attempting to request a scoped token for %s\n", projectName)
 	cloud := getCloudWithScopedTokenFromServiceProvider(projectName)
 	config.UpdateCloudConfig(cloud)
 	log.Println("info: scoped token acquired successfully")

--- a/iam/projects.go
+++ b/iam/projects.go
@@ -24,7 +24,7 @@ func GetProjectsInActiveCloud() config.Projects {
 	}
 
 	config.UpdateProjects(cloudProjects)
-	log.Printf("Projects for active cloud:\n%s \n", strings.Join(cloudProjects.GetProjectNames(), ",\n"))
+	log.Printf("info: projects for active cloud:\n%s \n", strings.Join(cloudProjects.GetProjectNames(), ",\n"))
 	return cloudProjects
 }
 

--- a/login/login.go
+++ b/login/login.go
@@ -25,7 +25,7 @@ func AuthenticateAndGetUnscopedToken(authInfo common.AuthInfo, skipTLS bool) {
 		return
 	}
 
-	log.Println("Retrieving unscoped token for active cloud...")
+	log.Println("info: retrieving unscoped token for active cloud...")
 
 	var tokenResponse common.TokenResponse
 	switch authInfo.AuthType {
@@ -53,7 +53,7 @@ func AuthenticateAndGetUnscopedToken(authInfo common.AuthInfo, skipTLS bool) {
 	}
 	updateOTCInfoFile(tokenResponse, authInfo.Region)
 	createScopedTokenForEveryProject()
-	log.Println("Successfully obtained unscoped token!")
+	log.Println("info: successfully obtained unscoped token!")
 }
 
 func createScopedTokenForEveryProject() {


### PR DESCRIPTION
When logging in with oidc, if an error happened, otc-auth would exit with a program status number of 0, which could break scripts like:
```bash
otc-auth login idp-oidc --overwrite-token && \
otc-auth temp-access-token create --duration-seconds 86390
```

Also standardizes output a little