### PR TITLE
add support for `eu-ch2` region in IAM `endpoints.go`

### DIFF
--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -17,7 +17,7 @@ func BaseURLIam(region string) string {
 	}
 	switch region {
 	case "eu-ch2":
-		return fmt.Sprintf("https://iam-pub.eu-ch2.sc.otc.t-systems.com:443/v3")
+		return "https://iam-pub.eu-ch2.sc.otc.t-systems.com:443/v3"
 	default:
 		return fmt.Sprintf("https://iam.%s.otc.t-systems.com:443/v3", region)
 	}

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -15,7 +15,12 @@ func BaseURLIam(region string) string {
 	if region == "" {
 		log.Fatal(errors.New("empty region supplied, can't generate IAM URL"))
 	}
-	return fmt.Sprintf("https://iam.%s.otc.t-systems.com:443/v3", region)
+	switch region {
+	case "eu-ch2":
+		return fmt.Sprintf("https://iam-pub.eu-ch2.sc.otc.t-systems.com:443/v3")
+	default:
+		return fmt.Sprintf("https://iam.%s.otc.t-systems.com:443/v3", region)
+	}
 }
 
 func IdentityProviders(identityProvider string, protocol string, region string) string {


### PR DESCRIPTION
hello there,

`eu-ch2` aka swisscloud uses a different API [endpoint](https://docs.sc.otc.t-systems.com/additional/endpoints.html) naming convention, I have updated `common/endpoints/endpoints.go` to support swisscloud IAM endpoint. Ran `go fmt` and tested auth on `eu-de` and on `eu-ch2` as well. Not sure if there is any test suites I should be using when contributing to your project, if I missed it, please point me to the direction thanks!

```
./otc-auth login iam --os-username $MYUSER --os-password $MYPW --os-domain-name $MYDOMAIN --region eu-ch2             
2023/12/19 15:34:10 info: cloud REDACTED loaded successfully and set to active.
2023/12/19 15:34:10 info: retrieving unscoped token for active cloud...
2023/12/19 15:34:11 info: fetching projects for cloud REDACTED
2023/12/19 15:34:13 info: projects for active cloud:
REDACTED
REDACTED
REDACTED
2023/12/19 15:34:27 info: scoped token acquired successfully
2023/12/19 15:34:27 info: successfully obtained unscoped token!
```