### PR TITLE
Fix MFA validation

### DIFF
--- a/common/model.go
+++ b/common/model.go
@@ -14,7 +14,7 @@ type AuthInfo struct {
 	AuthProtocol     string
 	DomainName       string
 	Otp              string
-	UserDomainID     string
+	UserID           string
 	ClientID         string
 	ClientSecret     string
 	OverwriteFile    bool

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -22,9 +22,8 @@ func AuthenticateAndGetUnscopedToken(authInfo common.AuthInfo) common.TokenRespo
 		IdentityEndpoint: endpoints.BaseURLIam(authInfo.Region),
 
 		Passcode: authInfo.Otp,
-		UserID:   authInfo.UserDomainID,
+		UserID:   authInfo.UserID,
 	}
-
 	provider, err := openstack.AuthenticatedClient(authOpts)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The rules set for validating cli args with Cobra were not correct. This PR removes the "required" flag on the username as the username should not be set when logging in with MFA (the user ID should be used instead). Custom validation has been added instead.

Closes https://github.com/iits-consulting/otc-auth/issues/78