### PR TITLE
Warn if token too long

### DIFF
--- a/accesstoken/accesstoken.go
+++ b/accesstoken/accesstoken.go
@@ -18,7 +18,7 @@ import (
 )
 
 func CreateAccessToken(tokenDescription string, printAkSk bool) {
-	glog.V(1).Infof("info: creating access token file with GTC...")
+	glog.V(1).Infof("info: creating access token file with GTC...\n")
 	resp, err := getAccessTokenFromServiceProvider(tokenDescription)
 	if err != nil {
 		// A 404 error is thrown when trying to create a permanent AK/SK when logged in with OIDC or SAML

--- a/login/login.go
+++ b/login/login.go
@@ -21,7 +21,7 @@ func AuthenticateAndGetUnscopedToken(authInfo common.AuthInfo, skipTLS bool) {
 	if config.IsAuthenticationValid() && !authInfo.OverwriteFile {
 		glog.V(1).Info(
 			"info: will not retrieve unscoped token, because the current one is still valid.\n" +
-				"\nTo overwrite the existing unscoped token, pass the \"--overwrite-token\" argument")
+				"To overwrite the existing unscoped token, pass the \"--overwrite-token\" argument")
 		return
 	}
 

--- a/oidc/server.go
+++ b/oidc/server.go
@@ -29,9 +29,10 @@ const (
 	localhost   = "localhost:8088"
 	redirectURL = "http://localhost:8088/oidc/auth"
 
-	queryState   = "state"
-	queryCode    = "code"
-	idTokenField = "id_token"
+	queryState             = "state"
+	queryCode              = "code"
+	idTokenField           = "id_token"
+	normalMaxIdTokenLength = 2300
 )
 
 func handleRoot(w http.ResponseWriter, r *http.Request) {
@@ -71,6 +72,9 @@ func startAndListenHTTPServer(channel chan common.OidcCredentialsResponse) {
 		if !ok {
 			http.Error(w, "No id_token field in oauth2 token", http.StatusInternalServerError)
 			return
+		}
+		if len(idToken) > normalMaxIdTokenLength {
+			glog.Warningf("warning: id token longer than %d characters - consider removing some groups or roles", normalMaxIdTokenLength)
 		}
 		rawIDToken, err := idTokenVerifier.Verify(backgroundCtx, idToken)
 		if err != nil {

--- a/oidc/server.go
+++ b/oidc/server.go
@@ -32,7 +32,7 @@ const (
 	queryState             = "state"
 	queryCode              = "code"
 	idTokenField           = "id_token"
-	normalMaxIdTokenLength = 2300
+	normalMaxIDTokenLength = 2300
 )
 
 func handleRoot(w http.ResponseWriter, r *http.Request) {
@@ -73,8 +73,9 @@ func startAndListenHTTPServer(channel chan common.OidcCredentialsResponse) {
 			http.Error(w, "No id_token field in oauth2 token", http.StatusInternalServerError)
 			return
 		}
-		if len(idToken) > normalMaxIdTokenLength {
-			glog.Warningf("warning: id token longer than %d characters - consider removing some groups or roles", normalMaxIdTokenLength)
+		if len(idToken) > normalMaxIDTokenLength {
+			glog.Warningf("warning: id token longer than %d characters"+
+				" - consider removing some groups or roles", normalMaxIDTokenLength)
 		}
 		rawIDToken, err := idTokenVerifier.Verify(backgroundCtx, idToken)
 		if err != nil {


### PR DESCRIPTION
If too many groups or roles are joined, issues using the token will arise