### PR TITLE
fix(config): use the correct schema in the kube config file

### DIFF
--- a/cce/cce.go
+++ b/cce/cce.go
@@ -1,10 +1,9 @@
 package cce
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"os"
 	"strconv"
 	"strings"
 
@@ -61,15 +60,15 @@ func GetKubeConfig(configParams KubeConfigParams, skipKubeTLS bool, printKubeCon
 	}
 
 	if printKubeConfig {
-		configBytes, errMarshal := json.Marshal(kubeConfig)
+		// Create a configuration file in kubectl-compatible format
+		configBytes, errMarshal := clientcmd.Write(kubeConfig)
 		if errMarshal != nil {
 			glog.Fatal(errMarshal)
 		}
-		configBytes = append([]byte{'\n'}, configBytes...)
-		configBytes = append(configBytes, '\n', '\n')
-		_, errWriter := log.Writer().Write(configBytes)
+		// Output the YAML data to STDOUT, since STDERR already contains log messages
+		_, err = os.Stdout.Write(configBytes)
 		if err != nil {
-			glog.Fatal(errWriter)
+			glog.Fatal("Error writing YAML to STDOUT")
 		}
 		glog.V(1).Info("info: successfully fetched kube config for cce cluster %s. \n", configParams.ClusterName)
 	} else {


### PR DESCRIPTION
Currently, there are a few issues when I want the `otc-auth` tool to obtain CCE credentials and output them so that I can forward the output into a file:

```
otc-auth cce get-kube-config \
    --cluster "${TF_VAR_context}-${TF_VAR_stage}" \
    --days-valid 7 \
    --output \
> kubeconfig.yaml
```

1. The `otc-auth` outputs the config file to STDERR, which already may contain log messages. That makes the `kubeconfig.yaml` not readable by `kubectl`.
2. Even if there are no logs in the STDERR, the format of the generated JSON(YAML) is incompatible with the `kubectl` tool.

This pull request solves both of the above issues.