### PR TITLE
Add aliases

### DIFF
--- a/cce/cce.go
+++ b/cce/cce.go
@@ -42,8 +42,8 @@ func GetClusterNames(projectName string) config.Clusters {
 	return clustersArr
 }
 
-func GetKubeConfig(configParams KubeConfigParams, skipKubeTLS bool, printKubeConfig bool) {
-	kubeConfig, err := getKubeConfig(configParams)
+func GetKubeConfig(configParams KubeConfigParams, skipKubeTLS bool, printKubeConfig bool, alias string) {
+	kubeConfig, err := getKubeConfig(configParams, alias)
 	if err != nil {
 		common.ThrowError(err)
 	}
@@ -97,7 +97,9 @@ func getClustersForProjectFromServiceProvider(projectName string) ([]clusters.Cl
 	return clusters.List(client, clusters.ListOpts{})
 }
 
-func getClusterCertFromServiceProvider(kubeConfigParams KubeConfigParams, clusterID string) (api.Config, error) {
+func getClusterCertFromServiceProvider(kubeConfigParams KubeConfigParams,
+	clusterID string, alias string,
+) (api.Config, error) {
 	project := config.GetActiveCloudConfig().Projects.GetProjectByNameOrThrow(kubeConfigParams.ProjectName)
 	cloud := config.GetActiveCloudConfig()
 	provider, err := openstack.AuthenticatedClient(golangsdk.AuthOptions{
@@ -121,7 +123,7 @@ func getClusterCertFromServiceProvider(kubeConfigParams KubeConfigParams, cluste
 	}
 	cert := clusters.GetCertWithExpiration(client, clusterID, expOpts).Body
 	certWithContext := addContextInformationToKubeConfig(kubeConfigParams.ProjectName,
-		kubeConfigParams.ClusterName, string(cert))
+		kubeConfigParams.ClusterName, string(cert), alias)
 	extractedCert, err := clientcmd.NewClientConfigFromBytes([]byte(certWithContext))
 	if err != nil {
 		common.ThrowError(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,7 +192,7 @@ var cceGetKubeConfigCmd = &cobra.Command{
 			Server:         server,
 		}
 
-		cce.GetKubeConfig(kubeConfigParams, skipKubeTLS, printKubeConfig)
+		cce.GetKubeConfig(kubeConfigParams, skipKubeTLS, printKubeConfig, alias)
 	},
 }
 
@@ -391,6 +391,7 @@ func setupRootCmd() {
 	cceCmd.AddCommand(cceGetKubeConfigCmd)
 	cceGetKubeConfigCmd.Flags().BoolVarP(&printKubeConfig, printKubeConfigFlag, printKubeConfigShortFlag,
 		false, printKubeConfigUsage)
+	cceGetKubeConfigCmd.Flags().StringVarP(&alias, aliasFlag, aliasShortFlag, "", aliasUsage)
 	cceGetKubeConfigCmd.Flags().StringVarP(&clusterName, clusterNameFlag, clusterNameShortFlag, "", clusterNameUsage)
 	cceGetKubeConfigCmd.Flags().BoolVarP(&skipKubeTLS, skipKubeTLSFlag, "", false, skipKubeTLSUsage)
 	cceGetKubeConfigCmd.Flags().IntVarP(
@@ -507,6 +508,7 @@ var (
 	openStackConfigLocation             string
 	skipTLS                             bool
 	printKubeConfig                     bool
+	alias                               string
 	clientSecret                        string
 	clientID                            string
 	oidcScopes                          []string
@@ -705,6 +707,9 @@ $ otc-auth access-token delete --token YourToken --os-domain-name YourDomain`
 	userIDEnv           = "OS_USER_DOMAIN_ID"
 	userIDUsage         = "User Id number, can be obtained on the \"My Credentials page\" on the OTC. Required if --totp is provided.  Either provide this argument or set the environment variable " + userIDEnv
 	regionFlag          = "region"
+	aliasFlag           = "alias"
+	aliasShortFlag      = "a"
+	aliasUsage          = "Setting this changes the naming scheme for clusters in the Kube Config from {project name}/{cluster name} to the alias set"
 	skipKubeTLSFlag     = "skip-kube-tls"
 	skipKubeTLSUsage    = "Setting this adds the insecure-skip-tls-verify rule to the config for every cluster"
 	regionShortFlag     = "r"


### PR DESCRIPTION
Thanks to a suggestion by @aazon, we can now override the naming convention of projectName/clusterName in the kube config by adding `--alias yourAlias` when getting the kube config.