### PR TITLE
fix: keep insecure-skip-tls-verify from CCE API response in generated kubeconfig

### DIFF
--- a/cce/cce.go
+++ b/cce/cce.go
@@ -274,6 +274,14 @@ func getKubeConfFromServiceProvider(kubeConfigParams KubeConfigParams,
 	return rawConfig, nil
 }
 
+func decodeB64(encoded, description, name string) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode %s '%s': %w", description, name, err)
+	}
+	return decoded, nil
+}
+
 func certToKubeConfig(cert *clusters.Certificate) (*api.Config, error) {
 	rawConfig := api.Config{
 		Kind:           cert.Kind,
@@ -286,26 +294,29 @@ func certToKubeConfig(cert *clusters.Certificate) (*api.Config, error) {
 	}
 
 	for _, c := range cert.Clusters {
-		decodedCA, errDecode := base64.StdEncoding.DecodeString(c.Cluster.CertAuthorityData)
-		if errDecode != nil {
-			return nil, fmt.Errorf("failed to decode cluster cert auth data for cluster '%s': %w",
-				c.Name, errDecode)
+		decodedCA, err := decodeB64(c.Cluster.CertAuthorityData, "cluster cert auth data for cluster", c.Name)
+		if err != nil {
+			return nil, err
 		}
-		rawConfig.Clusters[c.Name] = &api.Cluster{
-			Server:                   c.Cluster.Server,
-			CertificateAuthorityData: decodedCA,
-			InsecureSkipTLSVerify:    c.Cluster.InsecureSkipTLSVerify,
+		cluster := &api.Cluster{Server: c.Cluster.Server}
+		// client-go rejects a cluster entry carrying both CA data and the
+		// insecure flag, so propagate the flag only when no CA is present
+		if len(decodedCA) > 0 {
+			cluster.CertificateAuthorityData = decodedCA
+		} else {
+			cluster.InsecureSkipTLSVerify = c.Cluster.InsecureSkipTLSVerify
 		}
+		rawConfig.Clusters[c.Name] = cluster
 	}
 
 	for _, u := range cert.Users {
-		decodedCert, errDecode := base64.StdEncoding.DecodeString(u.User.ClientCertData)
-		if errDecode != nil {
-			return nil, fmt.Errorf("failed to decode client certificate data for user '%s': %w", u.Name, errDecode)
+		decodedCert, err := decodeB64(u.User.ClientCertData, "client certificate data for user", u.Name)
+		if err != nil {
+			return nil, err
 		}
-		decodedKey, errDecode := base64.StdEncoding.DecodeString(u.User.ClientKeyData)
-		if errDecode != nil {
-			return nil, fmt.Errorf("failed to decode client key data for user '%s': %w", u.Name, errDecode)
+		decodedKey, err := decodeB64(u.User.ClientKeyData, "client key data for user", u.Name)
+		if err != nil {
+			return nil, err
 		}
 		rawConfig.AuthInfos[u.Name] = &api.AuthInfo{
 			ClientCertificateData: decodedCert,

--- a/cce/cce.go
+++ b/cce/cce.go
@@ -262,6 +262,19 @@ func getKubeConfFromServiceProvider(kubeConfigParams KubeConfigParams,
 		return nil, fmt.Errorf("couldn't get cert: %w", err)
 	}
 
+	rawConfig, err := certToKubeConfig(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	err = renameKubeconfigEntries(rawConfig, kubeConfigParams.ProjectName, kubeConfigParams.ClusterName, alias)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't rename entries: %w", err)
+	}
+	return rawConfig, nil
+}
+
+func certToKubeConfig(cert *clusters.Certificate) (*api.Config, error) {
 	rawConfig := api.Config{
 		Kind:           cert.Kind,
 		APIVersion:     cert.ApiVersion,
@@ -276,22 +289,23 @@ func getKubeConfFromServiceProvider(kubeConfigParams KubeConfigParams,
 		decodedCA, errDecode := base64.StdEncoding.DecodeString(c.Cluster.CertAuthorityData)
 		if errDecode != nil {
 			return nil, fmt.Errorf("failed to decode cluster cert auth data for cluster '%s': %w",
-				c.Name, err)
+				c.Name, errDecode)
 		}
 		rawConfig.Clusters[c.Name] = &api.Cluster{
 			Server:                   c.Cluster.Server,
 			CertificateAuthorityData: decodedCA,
+			InsecureSkipTLSVerify:    c.Cluster.InsecureSkipTLSVerify,
 		}
 	}
 
 	for _, u := range cert.Users {
 		decodedCert, errDecode := base64.StdEncoding.DecodeString(u.User.ClientCertData)
 		if errDecode != nil {
-			return nil, fmt.Errorf("failed to decode client certificate data for user '%s': %w", u.Name, err)
+			return nil, fmt.Errorf("failed to decode client certificate data for user '%s': %w", u.Name, errDecode)
 		}
 		decodedKey, errDecode := base64.StdEncoding.DecodeString(u.User.ClientKeyData)
 		if errDecode != nil {
-			return nil, fmt.Errorf("failed to decode client key data for user '%s': %w", u.Name, err)
+			return nil, fmt.Errorf("failed to decode client key data for user '%s': %w", u.Name, errDecode)
 		}
 		rawConfig.AuthInfos[u.Name] = &api.AuthInfo{
 			ClientCertificateData: decodedCert,
@@ -306,10 +320,6 @@ func getKubeConfFromServiceProvider(kubeConfigParams KubeConfigParams,
 		}
 	}
 
-	err = renameKubeconfigEntries(&rawConfig, kubeConfigParams.ProjectName, kubeConfigParams.ClusterName, alias)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't rename entries: %w", err)
-	}
 	return &rawConfig, nil
 }
 

--- a/cce/cce_test.go
+++ b/cce/cce_test.go
@@ -28,10 +28,19 @@ func Test_certToKubeConfig(t *testing.T) {
 		CertificateAuthorityData: []byte(caData),
 	}
 	wantExternal := &api.Cluster{
-		Server: "https://80.158.0.1:5443",
-		// decoding the empty CA string yields an empty, non-nil slice
-		CertificateAuthorityData: []byte{},
-		InsecureSkipTLSVerify:    true,
+		Server:                "https://80.158.0.1:5443",
+		InsecureSkipTLSVerify: true,
+	}
+	// CA data and the insecure flag are mutually exclusive in the output:
+	// client-go rejects entries carrying both
+	bothSet := clusters.CertClusters{Name: externalClusterName, Cluster: clusters.CertCluster{
+		Server:                "https://80.158.0.1:5443",
+		CertAuthorityData:     caDataB64,
+		InsecureSkipTLSVerify: true,
+	}}
+	wantBothSet := &api.Cluster{
+		Server:                   "https://80.158.0.1:5443",
+		CertificateAuthorityData: []byte(caData),
 	}
 
 	tests := []struct {
@@ -51,6 +60,11 @@ func Test_certToKubeConfig(t *testing.T) {
 				internalClusterName: wantInternal,
 				externalClusterName: wantExternal,
 			},
+		},
+		{
+			name:     "CA data wins over insecure flag when the API sets both",
+			clusters: []clusters.CertClusters{bothSet},
+			want:     map[string]*api.Cluster{externalClusterName: wantBothSet},
 		},
 	}
 
@@ -72,5 +86,34 @@ func Test_certToKubeConfig(t *testing.T) {
 				t.Errorf("certToKubeConfig() clusters mismatch:\ngot = %+v\nwant = %+v", got.Clusters, tt.want)
 			}
 		})
+	}
+}
+
+// certToKubeConfig maps the SDK cert structs field-by-field; a field added to
+// the SDK would otherwise be dropped silently (how insecure-skip-tls-verify
+// went missing in the first place, see PR #182). This pins the field sets so
+// the mapping must be revisited when the SDK grows.
+func Test_certToKubeConfig_coversAllSDKFields(t *testing.T) {
+	t.Parallel()
+
+	handled := map[reflect.Type][]string{
+		reflect.TypeOf(clusters.CertCluster{}): {"Server", "CertAuthorityData", "InsecureSkipTLSVerify"},
+		reflect.TypeOf(clusters.CertUser{}):    {"ClientCertData", "ClientKeyData"},
+		reflect.TypeOf(clusters.CertContext{}): {"Cluster", "User"},
+	}
+
+	for typ, fields := range handled {
+		known := make(map[string]bool, len(fields))
+		for _, f := range fields {
+			known[f] = true
+		}
+		for i := range typ.NumField() {
+			if name := typ.Field(i).Name; !known[name] {
+				t.Errorf("%s.%s is not mapped by certToKubeConfig — update the mapping and this list", typ.Name(), name)
+			}
+		}
+		if typ.NumField() < len(fields) {
+			t.Errorf("%s lost fields; update the handled list", typ.Name())
+		}
 	}
 }

--- a/cce/cce_test.go
+++ b/cce/cce_test.go
@@ -3,9 +3,11 @@ package cce
 
 import (
 	"encoding/base64"
+	"reflect"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func Test_certToKubeConfig(t *testing.T) {
@@ -13,38 +15,42 @@ func Test_certToKubeConfig(t *testing.T) {
 
 	caData := "fake-ca-data"
 	caDataB64 := base64.StdEncoding.EncodeToString([]byte(caData))
+	internal := clusters.CertClusters{Name: internalClusterName, Cluster: clusters.CertCluster{
+		Server:            "https://192.168.0.1:5443",
+		CertAuthorityData: caDataB64,
+	}}
+	external := clusters.CertClusters{Name: externalClusterName, Cluster: clusters.CertCluster{
+		Server:                "https://80.158.0.1:5443",
+		InsecureSkipTLSVerify: true,
+	}}
+	wantInternal := &api.Cluster{
+		Server:                   "https://192.168.0.1:5443",
+		CertificateAuthorityData: []byte(caData),
+	}
+	wantExternal := &api.Cluster{
+		Server: "https://80.158.0.1:5443",
+		// decoding the empty CA string yields an empty, non-nil slice
+		CertificateAuthorityData: []byte{},
+		InsecureSkipTLSVerify:    true,
+	}
 
 	tests := []struct {
-		name         string
-		clusters     []clusters.CertClusters
-		wantInsecure map[string]bool
-		wantCAData   map[string]string
+		name     string
+		clusters []clusters.CertClusters
+		want     map[string]*api.Cluster
 	}{
 		{
-			name: "Jumbo setup without EIP: CA data only, no insecure flag",
-			clusters: []clusters.CertClusters{
-				{Name: "internalCluster", Cluster: clusters.CertCluster{
-					Server:            "https://192.168.0.1:5443",
-					CertAuthorityData: caDataB64,
-				}},
-			},
-			wantInsecure: map[string]bool{"internalCluster": false},
-			wantCAData:   map[string]string{"internalCluster": caData},
+			name:     "Jumbo setup without EIP: CA data only, no insecure flag",
+			clusters: []clusters.CertClusters{internal},
+			want:     map[string]*api.Cluster{internalClusterName: wantInternal},
 		},
 		{
-			name: "EIP bound: externalCluster has insecure-skip-tls-verify",
-			clusters: []clusters.CertClusters{
-				{Name: "internalCluster", Cluster: clusters.CertCluster{
-					Server:            "https://192.168.0.1:5443",
-					CertAuthorityData: caDataB64,
-				}},
-				{Name: "externalCluster", Cluster: clusters.CertCluster{
-					Server:                "https://80.158.0.1:5443",
-					InsecureSkipTLSVerify: true,
-				}},
+			name:     "EIP bound: externalCluster has insecure-skip-tls-verify",
+			clusters: []clusters.CertClusters{internal, external},
+			want: map[string]*api.Cluster{
+				internalClusterName: wantInternal,
+				externalClusterName: wantExternal,
 			},
-			wantInsecure: map[string]bool{"internalCluster": false, "externalCluster": true},
-			wantCAData:   map[string]string{"internalCluster": caData, "externalCluster": ""},
 		},
 	}
 
@@ -62,22 +68,8 @@ func Test_certToKubeConfig(t *testing.T) {
 				t.Fatalf("certToKubeConfig() error = %v", err)
 			}
 
-			if len(got.Clusters) != len(tt.clusters) {
-				t.Fatalf("got %d clusters, want %d", len(got.Clusters), len(tt.clusters))
-			}
-			for name, wantInsecure := range tt.wantInsecure {
-				cluster, ok := got.Clusters[name]
-				if !ok {
-					t.Fatalf("cluster %q missing from kube config", name)
-				}
-				if cluster.InsecureSkipTLSVerify != wantInsecure {
-					t.Errorf("cluster %q InsecureSkipTLSVerify = %v, want %v",
-						name, cluster.InsecureSkipTLSVerify, wantInsecure)
-				}
-				if string(cluster.CertificateAuthorityData) != tt.wantCAData[name] {
-					t.Errorf("cluster %q CertificateAuthorityData = %q, want %q",
-						name, cluster.CertificateAuthorityData, tt.wantCAData[name])
-				}
+			if !reflect.DeepEqual(got.Clusters, tt.want) {
+				t.Errorf("certToKubeConfig() clusters mismatch:\ngot = %+v\nwant = %+v", got.Clusters, tt.want)
 			}
 		})
 	}

--- a/cce/cce_test.go
+++ b/cce/cce_test.go
@@ -1,0 +1,84 @@
+//nolint:testpackage // whitebox testing
+package cce
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+)
+
+func Test_certToKubeConfig(t *testing.T) {
+	t.Parallel()
+
+	caData := "fake-ca-data"
+	caDataB64 := base64.StdEncoding.EncodeToString([]byte(caData))
+
+	tests := []struct {
+		name         string
+		clusters     []clusters.CertClusters
+		wantInsecure map[string]bool
+		wantCAData   map[string]string
+	}{
+		{
+			name: "Jumbo setup without EIP: CA data only, no insecure flag",
+			clusters: []clusters.CertClusters{
+				{Name: "internalCluster", Cluster: clusters.CertCluster{
+					Server:            "https://192.168.0.1:5443",
+					CertAuthorityData: caDataB64,
+				}},
+			},
+			wantInsecure: map[string]bool{"internalCluster": false},
+			wantCAData:   map[string]string{"internalCluster": caData},
+		},
+		{
+			name: "EIP bound: externalCluster has insecure-skip-tls-verify",
+			clusters: []clusters.CertClusters{
+				{Name: "internalCluster", Cluster: clusters.CertCluster{
+					Server:            "https://192.168.0.1:5443",
+					CertAuthorityData: caDataB64,
+				}},
+				{Name: "externalCluster", Cluster: clusters.CertCluster{
+					Server:                "https://80.158.0.1:5443",
+					InsecureSkipTLSVerify: true,
+				}},
+			},
+			wantInsecure: map[string]bool{"internalCluster": false, "externalCluster": true},
+			wantCAData:   map[string]string{"internalCluster": caData, "externalCluster": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cert := &clusters.Certificate{
+				Kind:       "Config",
+				ApiVersion: "v1",
+				Clusters:   tt.clusters,
+			}
+
+			got, err := certToKubeConfig(cert)
+			if err != nil {
+				t.Fatalf("certToKubeConfig() error = %v", err)
+			}
+
+			if len(got.Clusters) != len(tt.clusters) {
+				t.Fatalf("got %d clusters, want %d", len(got.Clusters), len(tt.clusters))
+			}
+			for name, wantInsecure := range tt.wantInsecure {
+				cluster, ok := got.Clusters[name]
+				if !ok {
+					t.Fatalf("cluster %q missing from kube config", name)
+				}
+				if cluster.InsecureSkipTLSVerify != wantInsecure {
+					t.Errorf("cluster %q InsecureSkipTLSVerify = %v, want %v",
+						name, cluster.InsecureSkipTLSVerify, wantInsecure)
+				}
+				if string(cluster.CertificateAuthorityData) != tt.wantCAData[name] {
+					t.Errorf("cluster %q CertificateAuthorityData = %q, want %q",
+						name, cluster.CertificateAuthorityData, tt.wantCAData[name])
+				}
+			}
+		})
+	}
+}

--- a/cce/kube_config.go
+++ b/cce/kube_config.go
@@ -49,7 +49,24 @@ func mergeKubeConfig(configParams KubeConfigParams, kubeConfig api.Config) {
 
 func merge(currentConfig *api.Config, kubeConfig api.Config) error {
 	err := mergo.Merge(currentConfig, kubeConfig, mergo.WithOverride)
-	return err
+	if err != nil {
+		return err
+	}
+	// mergo deep-merges colliding entries and never overrides with empty
+	// values, so a re-fetched entry could keep stale CA data next to a
+	// freshly-set insecure-skip-tls-verify flag (a combination client-go
+	// rejects) and a once-set flag could never be cleared. Freshly fetched
+	// entries are authoritative: replace them wholesale.
+	for name, cluster := range kubeConfig.Clusters {
+		currentConfig.Clusters[name] = cluster
+	}
+	for name, authInfo := range kubeConfig.AuthInfos {
+		currentConfig.AuthInfos[name] = authInfo
+	}
+	for name, context := range kubeConfig.Contexts {
+		currentConfig.Contexts[name] = context
+	}
+	return nil
 }
 
 func determineTargetLocation(targetLocation string) string {

--- a/cce/kube_config.go
+++ b/cce/kube_config.go
@@ -16,6 +16,11 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
+const (
+	internalClusterName = "internalCluster"
+	externalClusterName = "externalCluster"
+)
+
 func getKubeConfig(kubeConfigParams KubeConfigParams, alias string) (*api.Config, error) {
 	glog.V(common.InfoLogLevel).Infof("info: getting kube config...")
 
@@ -70,8 +75,8 @@ func renameKubeconfigEntries(rawConfig *api.Config, projectName, clusterName, al
 	}
 
 	clusterRenames := map[string]string{
-		"internalCluster": fmt.Sprintf("%s-intranet", alias),
-		"externalCluster": alias,
+		internalClusterName: fmt.Sprintf("%s-intranet", alias),
+		externalClusterName: alias,
 	}
 	userRenames := map[string]string{
 		"user": fmt.Sprintf("%s-%s-%s", projectName, clusterName, activeCloud.Username),

--- a/cce/kube_config_test.go
+++ b/cce/kube_config_test.go
@@ -77,6 +77,37 @@ func Test_merge(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			// a user's existing entry may hold CA data from an older fetch or manual
+			// workaround; the fresh API entry (insecure, no CA) must replace it wholesale,
+			// otherwise the merged entry carries both fields and client-go rejects it
+			name: "Stale CA data does not survive a fresh insecure entry",
+			currentConfig: &api.Config{Clusters: map[string]*api.Cluster{
+				"alias": {Server: "server-a", CertificateAuthorityData: []byte("stale-ca")},
+			}},
+			kubeConfig: api.Config{Clusters: map[string]*api.Cluster{
+				"alias": {Server: "server-a", InsecureSkipTLSVerify: true},
+			}},
+			expectedConfig: api.Config{Clusters: map[string]*api.Cluster{
+				"alias": {Server: "server-a", InsecureSkipTLSVerify: true},
+			}},
+			wantErr: false,
+		},
+		{
+			// the inverse direction: a previously-set insecure flag (zero value in the
+			// fresh entry) must not stick around once the API returns proper CA data
+			name: "Sticky insecure flag is cleared by a fresh CA entry",
+			currentConfig: &api.Config{Clusters: map[string]*api.Cluster{
+				"alias": {Server: "server-a", InsecureSkipTLSVerify: true},
+			}},
+			kubeConfig: api.Config{Clusters: map[string]*api.Cluster{
+				"alias": {Server: "server-a", CertificateAuthorityData: []byte("new-ca")},
+			}},
+			expectedConfig: api.Config{Clusters: map[string]*api.Cluster{
+				"alias": {Server: "server-a", CertificateAuthorityData: []byte("new-ca")},
+			}},
+			wantErr: false,
+		},
+		{
 			name: "Nil currentConfig should error",
 			// Merge requires a non-nil currentConfig pointer because it merges data *into* the
 			// existing object it points to. A nil pointer references no object, making the Merge impossible.


### PR DESCRIPTION
## Problem

When an EIP is bound to a CCE cluster, the cluster certificate API returns `insecure-skip-tls-verify: true` on the `externalCluster` entry. otc-auth dropped this flag when converting the API response into a kubeconfig, so the generated config fails TLS verification against the EIP endpoint.

## Fix

Copy `InsecureSkipTLSVerify` from the API response into the generated cluster entry (`cce/cce.go`). The generated kubeconfig now mirrors the API response, so both setups work: clusters without an EIP (e.g. the standard Jumbo/KumoOps setup) are unaffected since the API does not set the flag there, and EIP-bound clusters get the flag on `externalCluster`.

Along the way:
- Extracted the cert-response-to-kubeconfig mapping into `certToKubeConfig` so it is testable without a live API, with tests covering both the no-EIP and EIP-bound cases.
- Fixed the base64-decode error paths, which wrapped the wrong (always nil) error variable and would have produced misleading messages on decode failure.

## Dependency bump

Second commit bumps `golang.org/x/net` 0.47.0 → 0.55.0 (plus the sibling `x/sys`, `x/term`, `x/text` versions it requires).